### PR TITLE
Reduce priority of kernel.controller listener

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,7 +15,7 @@
                  class="Webfactory\Bundle\LegacyIntegrationBundle\EventListener\LegacyApplicationDispatchingEventListener">
             <argument type="service" id="service_container"/>
             <argument type="service" id="annotation_reader"/>
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
+            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-210" />
         </service>
 
         <service class="Webfactory\Bundle\LegacyIntegrationBundle\Integration\Filter\ControllerAnnotations">


### PR DESCRIPTION
The `LegacyApplicationDispatchingEventListener` currently has default priority (0). Now when it is used to dispatch the legacy application (the `@LegacyIntegration\Dispatch` annotation) and to return the response unchanged (`@LegacyIntegration\Passthru`), the `PassthruLegacyResponseFilter` will [replace the controller](https://github.com/webfactory/legacy-integration-bundle/blob/master/Integration/Filter/PassthruLegacyResponseFilter.php#L28) with an anonymous function.

This does not play nicely with other `kernel.controller` event listeners that need to have a look at the controller. One notable example is SensioFrameworkExtraBundle which provides a [@Cache annotation](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/cache.html). If `LegacyApplicationDispatchingEventListener` comes first and applies the `PassthruLegacyResponseFilter`, the `ControllerListener` will fail [here](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/EventListener/ControllerListener.php#L54).

By reducing the priority, the `@Cache` annotation can be used to control cache-expiry headers for the _legacy_ response from within Symfony 2.
