### PR TITLE
Override $_SERVER params via annotation

### DIFF
--- a/EventListener/LegacyApplicationDispatchingEventListener.php
+++ b/EventListener/LegacyApplicationDispatchingEventListener.php
@@ -54,13 +54,17 @@ class LegacyApplicationDispatchingEventListener
         foreach ($this->reader->getMethodAnnotations($method) as $configuration) {
             if ($configuration instanceof Dispatch) {
                 $dispatch = true;
-                $dispatchConfig = $configuration->getPath();
-                $dispatchPath = null;
-                if($dispatchConfig) {
-                    $dispatchPath = array_key_exists('path' , $dispatchConfig) ? $dispatchConfig['path'] : null;
+                $dispatchConfig = $configuration->getServer();
+                if(empty($dispatchConfig)) {
+                    break;
                 }
+                $dispatchServer = array_key_exists('server' , $dispatchConfig) ? $dispatchConfig['server'] : null;
                 $request = $request->duplicate();
-                $request->server->set('REQUEST_URI', $dispatchPath);
+                $server = $_SERVER;
+                foreach($dispatchServer as $k=>$v) {
+                    $server[$k] = $v;
+                }
+                $request->server->replace($server);
                 break;
             }
         }

--- a/Integration/Annotation/Dispatch.php
+++ b/Integration/Annotation/Dispatch.php
@@ -13,4 +13,17 @@ namespace Webfactory\Bundle\LegacyIntegrationBundle\Integration\Annotation;
  */
 class Dispatch
 {
+    private $path = null;
+
+    public function __construct($path = null)
+    {
+        if($path !== null) {
+            $this->path = $path;
+        }
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
 }

--- a/Integration/Annotation/Dispatch.php
+++ b/Integration/Annotation/Dispatch.php
@@ -13,17 +13,17 @@ namespace Webfactory\Bundle\LegacyIntegrationBundle\Integration\Annotation;
  */
 class Dispatch
 {
-    private $path = null;
+    private $server = null;
 
-    public function __construct($path = null)
+    public function __construct($server = null)
     {
-        if($path !== null) {
-            $this->path = $path;
+        if($server !== null) {
+            $this->server = $server;
         }
     }
 
-    public function getPath()
+    public function getServer()
     {
-        return $this->path;
+        return $this->server;
     }
 }

--- a/Integration/BootstrapFileKernelAdaptor.php
+++ b/Integration/BootstrapFileKernelAdaptor.php
@@ -25,7 +25,11 @@ class BootstrapFileKernelAdaptor implements HttpKernelInterface
     {
         $file = $this->file;
         return LegacyCaptureResponseFactory::create(function () use ($file, $request) {
-            return include($file);
+            $_SERVER_BAK = $_SERVER;
+            $_SERVER = $request->server->all();
+            $include = include($file);
+            $_SERVER = $_SERVER_BAK;
+            return $include;
         });
     }
 }


### PR DESCRIPTION
This commit allows to pass $_SERVER parameters to be overwritten in the Legacy Request.

Example use: Legacy app needs specific URL in $_SERVER super variable for its routing.

Usage:
@Legacy\Dispatch(server={"REQUEST_URI"="/legacy/app/route"})
