### PR TITLE
Relax Symfony version constraints for Symfony 2.8, 3.4 and 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "require": {
         "doctrine/annotations": "~1.0",
         "psr/log": "^1.0",
-        "symfony/config": "~2.2",
-        "symfony/dependency-injection": "~2.6",
-        "symfony/framework-bundle": "~2.2",
-        "symfony/http-foundation": "~2.2",
-        "symfony/http-kernel": "~2.2",
+        "symfony/config": "2.8.*|3.4.*|^4.0",
+        "symfony/dependency-injection": "2.8.*|3.4.*|^4.0",
+        "symfony/framework-bundle": "2.8.*|3.4.*|^4.0",
+        "symfony/http-foundation": "2.8.*|3.4.*|^4.0",
+        "symfony/http-kernel": "2.8.*|3.4.*|^4.0",
         "twig/twig": "^1.23",
         "webfactory/dom": "~1.0, >= 1.0.15"
     }


### PR DESCRIPTION
This fixes #11.
