### PR TITLE
Add some return type hints

### DIFF
--- a/Integration/BootstrapFileKernelAdaptor.php
+++ b/Integration/BootstrapFileKernelAdaptor.php
@@ -9,6 +9,7 @@
 namespace Webfactory\Bundle\LegacyIntegrationBundle\Integration;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class BootstrapFileKernelAdaptor implements HttpKernelInterface
@@ -20,6 +21,9 @@ class BootstrapFileKernelAdaptor implements HttpKernelInterface
         $this->file = $filename;
     }
 
+    /**
+     * @return Response
+     */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
         $file = $this->file;

--- a/Integration/LegacyApplication.php
+++ b/Integration/LegacyApplication.php
@@ -20,11 +20,14 @@ class LegacyApplication implements HttpKernelInterface
     /** @var HttpKernelInterface */
     protected $legacyKernel;
 
-    public function setLegacyKernel(HttpKernelInterface $kernel)
+    public function setLegacyKernel(HttpKernelInterface $kernel): void
     {
         $this->legacyKernel = $kernel;
     }
 
+    /**
+     * @return Response
+     */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
         if (null === $this->response) {
@@ -35,13 +38,12 @@ class LegacyApplication implements HttpKernelInterface
         return $this->response;
     }
 
-    public function isDispatched()
+    public function isDispatched(): bool
     {
         return null !== $this->response;
     }
 
-    /** @return Response */
-    public function getResponse()
+    public function getResponse(): Response
     {
         if (null === $this->response) {
             throw new LegacyIntegrationException('The legacy application has not been started or has not generated a response. Maybe the @Dispatch annotation is missing for the current controller?');

--- a/Integration/LegacyCaptureResponseFactory.php
+++ b/Integration/LegacyCaptureResponseFactory.php
@@ -8,9 +8,11 @@
 
 namespace Webfactory\Bundle\LegacyIntegrationBundle\Integration;
 
+use Symfony\Component\HttpFoundation\Response;
+
 class LegacyCaptureResponseFactory
 {
-    public static function create($legacyExecutionCallback)
+    public static function create($legacyExecutionCallback): Response
     {
         // Preserve all headers that have previously been set (pre-Legacy startup)
         $preLegacyHeaders = headers_list();
@@ -26,7 +28,7 @@ class LegacyCaptureResponseFactory
         }
     }
 
-    private static function runLegacyAndCaptureResponse($legacyExecutionCallback)
+    private static function runLegacyAndCaptureResponse($legacyExecutionCallback): Response
     {
         ob_start();
         try {

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -28,7 +28,7 @@ class Extension extends AbstractExtension implements GlobalsInterface, ServiceSu
      */
     private $embedResult = null;
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return [
             LegacyApplication::class,
@@ -41,7 +41,7 @@ class Extension extends AbstractExtension implements GlobalsInterface, ServiceSu
         $this->container = $container;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('webfactory_legacy_integration_embed', [$this, 'embedString']),
@@ -66,10 +66,8 @@ class Extension extends AbstractExtension implements GlobalsInterface, ServiceSu
      * Evaluate $xpath search query on the legacy content and get a string representation of matching elements.
      *
      * @param string $xpath
-     *
-     * @return string
      */
-    public function xpath($xpath)
+    public function xpath($xpath): string
     {
         return $this->getXPathHelper()->getFragment($xpath);
     }


### PR DESCRIPTION
This PR adds return type hints to resolve deprecation warnings issued by Symfony's DebugClassLoader in Symfony 5.4.

In places where we cannot reasonably rule out that methods have been overridden, only soft (docblock-based) types are added. 

In case you have overwritten these methods, you should start adding _real_ return type declarations _now_.